### PR TITLE
Fix offline Charging

### DIFF
--- a/rootdir/etc/init.g3.rc
+++ b/rootdir/etc/init.g3.rc
@@ -331,10 +331,9 @@ on post-fs-data
 # Services start here
 #
 
-service charger /sbin/healthd -c
+service charger /charger
     class charger
-    critical
-    seclabel u:r:healthd:s0
+    seclabel u:r:charger:s0
 
 service qcom-c_core-sh /system/bin/sh /init.qcom.class_core.sh
     class core


### PR DESCRIPTION
In Android Oreo Google removed the healthd binary and replaced it with charger so we use this one now